### PR TITLE
quickfix crash on mac when paste something in editor

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -510,10 +510,14 @@ open class TextView: UITextView {
     }
 
     open override func paste(_ sender: Any?) {
+	#if targetEnvironment(macCatalyst)
+	super.paste(sender)
+	#else
         guard pasteboardDelegate.tryPasting(in: self) else {
             super.paste(sender)
             return
         }
+	#endif
     }
 
     @objc open func pasteWithoutFormatting(_ sender: Any?) {


### PR DESCRIPTION
Fixes #

To test:
using mac : paste something on editor
---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
